### PR TITLE
Revert "manifest: Drop time services"

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -440,5 +440,6 @@
   <project path="vendor/qcom/opensource/dataservices" name="platform/vendor/qcom-opensource/dataservices" remote="caf" revision="LA.BF.1.1.3_rb1.12" />
   <project path="vendor/qcom/opensource/dpm" name="android_vendor_qcom-opensource_dpm" remote="aospa" />
   <project path="vendor/qcom/opensource/fm" name="platform/vendor/qcom-opensource/fm" remote="caf" revision="LA.HB.1.1.1" />
+  <project path="vendor/qcom/opensource/time-services" name="platform/vendor/qcom-opensource/time-services" remote="caf" />
 
 </manifest>


### PR DESCRIPTION
- we dropped the implementation in fwb, restore the header.

This reverts commit 3ac0333407998e418b89fea6989c76de7e9f2de8.

Change-Id: I9801d6f1d229cf48e24ed972bf8f685b0e5e1982
Signed-off-by: Alex Naidis alex.naidis@linux.com
